### PR TITLE
feat: add 3 new rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/eslint": "^8.37.0",
     "@types/jest": "^29.5.0",
+    "@types/node": "^20.11.0",
     "@typescript-eslint/parser": "^5.58.0",
     "eslint": "^8.38.0",
     "eslint-config-prettier": "^8.8.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,20 +2,36 @@ import { Linter } from "eslint";
 
 import { noUnnecessaryArraySpreadRule } from "./no-unnecessary-array-spread";
 import { noImmutableReduceRule } from "./no-immutable-reduce";
+import { preferUseLayoutEffectRule } from "./prefer-use-layout-effect";
+import { preferArrayFromRule } from "./prefer-array-from";
+import { preferFilterFirstRule } from "./prefer-filter-first";
 
 const recommended: Linter.BaseConfig = {
-    plugins: ["eslint-performance"],
-    rules: {
-        "eslint-performance/no-unnecessary-array-spread": "warn",
-        "eslint-performance/no-immutable-reduce": "warn",
-    },
+	plugins: ["eslint-performance"],
+	rules: {
+		"eslint-performance/no-unnecessary-array-spread": "warn",
+		"eslint-performance/no-immutable-reduce": "warn",
+		"eslint-performance/prefer-array-from": "warn",
+		"eslint-performance/prefer-filter-first": "warn",
+	},
+};
+
+const react: Linter.BaseConfig = {
+	plugins: ["eslint-performance"],
+	rules: {
+		"eslint-performance/prefer-use-layout-effect": "warn",
+	},
 };
 
 export const configs = {
-    recommended,
+	recommended,
+	react,
 };
 
 export const rules = {
-    "no-unnecessary-array-spread": noUnnecessaryArraySpreadRule,
-    "no-immutable-reduce": noImmutableReduceRule,
+	"no-unnecessary-array-spread": noUnnecessaryArraySpreadRule,
+	"no-immutable-reduce": noImmutableReduceRule,
+	"prefer-use-layout-effect": preferUseLayoutEffectRule,
+	"prefer-array-from": preferArrayFromRule,
+	"prefer-filter-first": preferFilterFirstRule,
 };

--- a/src/prefer-Array-from.ts
+++ b/src/prefer-Array-from.ts
@@ -1,7 +1,7 @@
 import { Rule } from "eslint";
 import { TSESTree } from "@typescript-eslint/experimental-utils";
 
-const arrayFromMapRule: Rule.RuleModule = {
+export const arrayFromMapRule: Rule.RuleModule = {
 	meta: {
 		type: "suggestion",
 		docs: {

--- a/src/prefer-Array-from.ts
+++ b/src/prefer-Array-from.ts
@@ -1,45 +1,46 @@
 import { Rule } from "eslint";
-import { TSESTree } from "@typescript-eslint/experimental-utils";
 
-export const arrayFromMapRule: Rule.RuleModule = {
+export const preferArrayFromRule: Rule.RuleModule = {
 	meta: {
 		type: "suggestion",
 		docs: {
-			description: "`Array.from(a, b)` is faster and equal to `Array.from(a).map(b)`",
+			description:
+				"`Array.from(a, b)` is faster and produces an equal result to `Array.from(a).map(b)`",
 			category: "Best Practices",
 			recommended: true,
 		},
+		// fixable: "code",
 	},
 	create: (context) => ({
-		CallExpression(node: TSESTree.CallExpression) {
-			const { callee } = node;
-			if (
-				callee.type === "MemberExpression" &&
-				callee.property &&
-				callee.property.name === "map" &&
-				callee.object &&
-				callee.object.type === "CallExpression" &&
-				callee.object.callee.object &&
-				callee.object.callee.object.type === "CallExpression" &&
-				callee.object.callee.object.callee.property &&
-				callee.object.callee.object.callee.property.name === "from"
-			) {
-				context.report({
-					node,
-					message: "Prefer using `Array.from(a, b)` instead of `Array.from(a).map(b)`.",
-					fix: (fixer) => {
-						const arrayFromArguments = callee.object.arguments.map((arg) => context.getSourceCode().getText(arg));
-						const mapArgument = node.arguments.map((arg) => context.getSourceCode().getText(arg));
-						const replacement = `Array.from(${arrayFromArguments[0]}, ${mapArgument[0]})`;
-
-						return fixer.replaceText(node, replacement);
-					},
-				});
+		CallExpression(node) {
+			if (node.callee.type !== "MemberExpression") {
+				return;
 			}
+
+			const callee = node.callee;
+			if (
+				callee.object.type !== "Identifier" ||
+				callee.object.name !== "Array" ||
+				callee.property.type !== "Identifier" ||
+				callee.property.name !== "from"
+			) {
+				return;
+			}
+
+			const parent = node.parent;
+			if (
+				parent.type !== "MemberExpression" ||
+				parent.property.type !== "Identifier" ||
+				parent.property.name !== "map"
+			) {
+				return;
+			}
+
+			context.report({
+				node: parent,
+				message:
+					"Prefer using `Array.from(arr, a => a)` over `Array.from(arr).map(a => a)` to avoid an unnecessary function call while keeping functionality equal.",
+			});
 		},
 	}),
-};
-
-export = {
-	arrayFromMapRule,
 };

--- a/src/prefer-Array-from.ts
+++ b/src/prefer-Array-from.ts
@@ -1,0 +1,45 @@
+import { Rule } from "eslint";
+import { TSESTree } from "@typescript-eslint/experimental-utils";
+
+const arrayFromMapRule: Rule.RuleModule = {
+	meta: {
+		type: "suggestion",
+		docs: {
+			description: "`Array.from(a, b)` is faster and equal to `Array.from(a).map(b)`",
+			category: "Best Practices",
+			recommended: true,
+		},
+	},
+	create: (context) => ({
+		CallExpression(node: TSESTree.CallExpression) {
+			const { callee } = node;
+			if (
+				callee.type === "MemberExpression" &&
+				callee.property &&
+				callee.property.name === "map" &&
+				callee.object &&
+				callee.object.type === "CallExpression" &&
+				callee.object.callee.object &&
+				callee.object.callee.object.type === "CallExpression" &&
+				callee.object.callee.object.callee.property &&
+				callee.object.callee.object.callee.property.name === "from"
+			) {
+				context.report({
+					node,
+					message: "Prefer using `Array.from(a, b)` instead of `Array.from(a).map(b)`.",
+					fix: (fixer) => {
+						const arrayFromArguments = callee.object.arguments.map((arg) => context.getSourceCode().getText(arg));
+						const mapArgument = node.arguments.map((arg) => context.getSourceCode().getText(arg));
+						const replacement = `Array.from(${arrayFromArguments[0]}, ${mapArgument[0]})`;
+
+						return fixer.replaceText(node, replacement);
+					},
+				});
+			}
+		},
+	}),
+};
+
+export = {
+	arrayFromMapRule,
+};

--- a/src/prefer-array-from.test.ts
+++ b/src/prefer-array-from.test.ts
@@ -1,0 +1,27 @@
+import { RuleTester } from "eslint";
+import { preferArrayFromRule } from "./prefer-array-from";
+
+const tester = new RuleTester({
+	parser: require.resolve("@typescript-eslint/parser"),
+	parserOptions: {
+		ecmaFeatures: {
+			jsx: true,
+		},
+	},
+});
+
+tester.run("prefer-array-from", preferArrayFromRule, {
+	valid: [],
+	invalid: [
+		{
+			code: "Array.from(a).map(a => a)",
+			errors: [
+				{
+					message:
+						"Prefer using `Array.from(arr, a => a)` over `Array.from(arr).map(a => a)` to avoid an unnecessary function call while keeping functionality equal.",
+				},
+			],
+			// output: "Array.from(a, a => a)",
+		},
+	],
+});

--- a/src/prefer-filter-first.test.ts
+++ b/src/prefer-filter-first.test.ts
@@ -1,0 +1,27 @@
+import { RuleTester } from "eslint";
+import { preferFilterFirstRule } from "./prefer-filter-first";
+
+const tester = new RuleTester({
+	parser: require.resolve("@typescript-eslint/parser"),
+	parserOptions: {
+		ecmaFeatures: {
+			jsx: true,
+		},
+	},
+});
+
+tester.run("prefer-filter-first", preferFilterFirstRule, {
+	valid: [],
+	invalid: [
+		{
+			code: "arr.map(a => a).filter(a => !a)",
+			errors: [
+				{
+					message:
+						"Prefer using `arr.filter(a => !a).map(a => a)` instead of `arr.map(a => a).filter(a => !a)` to reduce the iterations the `map` runs over.",
+				},
+			],
+			// output: "arr.filter(a => !a).map(a => a)",
+		},
+	],
+});

--- a/src/prefer-filter-first.test.ts
+++ b/src/prefer-filter-first.test.ts
@@ -21,7 +21,6 @@ tester.run("prefer-filter-first", preferFilterFirstRule, {
 						"Prefer using `arr.filter(a => !a).map(a => a)` instead of `arr.map(a => a).filter(a => !a)` to reduce the iterations the `map` runs over.",
 				},
 			],
-			// output: "arr.filter(a => !a).map(a => a)",
 		},
 	],
 });

--- a/src/prefer-filter-first.ts
+++ b/src/prefer-filter-first.ts
@@ -1,0 +1,42 @@
+import { Rule } from "eslint";
+import { TSESTree } from "@typescript-eslint/experimental-utils";
+
+const mapFilterRule: Rule.RuleModule = {
+	meta: {
+		type: "suggestion",
+		docs: {
+			description: "Calling `filter` first reduces the amount of iterations on the `map`.",
+			category: "Best Practices",
+			recommended: true,
+		},
+	},
+	create: (context) => ({
+		CallExpression(node: TSESTree.CallExpression) {
+			const { callee } = node;
+			if (
+				callee.type === "MemberExpression" &&
+				callee.property &&
+				callee.property.name === "filter" &&
+				callee.object &&
+				callee.object.type === "CallExpression" &&
+				callee.object.callee.property &&
+				callee.object.callee.property.name === "map"
+			) {
+				context.report({
+					node,
+					message: "Prefer using `.filter().map()` instead of `.map().filter()`.",
+					fix: (fixer) => {
+						const mapArguments = callee.object.arguments.map((arg) => context.getSourceCode().getText(arg));
+						const filterArguments = node.arguments.map((arg) => context.getSourceCode().getText(arg));
+						const replacement = `filter(${filterArguments[0]}).map(${mapArguments[0]})`;
+
+						return fixer.replaceText(node, replacement);
+					},
+				});
+			}
+		},
+	}),
+};
+export = {
+	mapFilterRule,
+};

--- a/src/prefer-use-layout-effect.test.ts
+++ b/src/prefer-use-layout-effect.test.ts
@@ -1,0 +1,42 @@
+import { RuleTester } from "eslint";
+import { preferUseLayoutEffectRule } from "./prefer-use-layout-effect";
+
+const tester = new RuleTester({
+	parser: require.resolve("@typescript-eslint/parser"),
+	parserOptions: {
+		ecmaFeatures: {
+			jsx: true,
+		},
+	},
+});
+
+tester.run("prefer-use-layout-effect", preferUseLayoutEffectRule, {
+	valid: [
+		{
+			code: `const Foo = () => {
+useLayoutEffect(() => {
+const d = node.getBoundingClientRect();
+}, []);
+
+return null;
+}`,
+		},
+	],
+	invalid: [
+		{
+			code: `const Foo = () => {
+useEffect(() => {
+const d = node.getBoundingClientRect();
+}, []);
+
+return null;
+}`,
+			errors: [
+				{
+					message:
+						"Prefer `useLayoutEffect` over `useEffect` when reading from DOM with `getBoundingClientRect` to avoid causing an extra reflow.",
+				},
+			],
+		},
+	],
+});

--- a/src/prefer-use-layout-effect.ts
+++ b/src/prefer-use-layout-effect.ts
@@ -1,35 +1,56 @@
 import { Rule } from "eslint";
-import { TSESTree } from "@typescript-eslint/experimental-utils";
 
-const rule: Rule.RuleModule = {
+export const preferUseLayoutEffectRule: Rule.RuleModule = {
 	meta: {
 		type: "suggestion",
 		docs: {
-			description: "`getBoundinggClientRect` is expensive, so it should be used in `useLayoutEffect`.",
+			description:
+				"`getBoundinggClientRect` causes [reflow](https://webperf.tips/tip/layout-thrashing/#react-development), so reading from DOM should be done in `useLayoutEffect`.",
 			category: "Best Practices",
 			recommended: true,
 		},
 	},
 	create: (context) => ({
-		CallExpression(node: TSESTree.CallExpression) {
-			const { callee } = node;
+		CallExpression(node) {
 			if (
-				callee.type === "MemberExpression" &&
-				callee.object.type === "CallExpression" &&
-				callee.object.callee.property &&
-				callee.object.callee.property.name === "getBoundingClientRect" &&
-				callee.object.callee.object &&
-				callee.object.callee.object.type === "ThisExpression" &&
-				callee.object.callee.object.type === "Identifier" &&
-				callee.object.callee.object.name === "useEffect"
-			) {
-				context.report({
-					node,
-					message: "Prefer using useLayoutEffect with getBoundingClientRect.",
-				});
-			}
+				node.callee.type !== "MemberExpression" ||
+				node.callee.property.type !== "Identifier" ||
+				node.callee.property.name !== "getBoundingClientRect"
+			)
+				return;
+
+			if (
+				!node.parent ||
+				!node.parent.parent ||
+				!node.parent.parent.parent ||
+				!node.parent.parent.parent.parent
+			)
+				return;
+
+			const parent = node.parent.parent.parent.parent;
+
+			if (
+				parent.type !== "ArrowFunctionExpression" &&
+				parent.type !== "FunctionExpression"
+			)
+				return;
+
+			if (!parent.parent) return;
+
+			const maybeUseEffect = parent.parent;
+
+			if (
+				maybeUseEffect.type !== "CallExpression" ||
+				maybeUseEffect.callee.type !== "Identifier" ||
+				maybeUseEffect.callee.name !== "useEffect"
+			)
+				return;
+
+			context.report({
+				node,
+				message:
+					"Prefer `useLayoutEffect` over `useEffect` when reading from DOM with `getBoundingClientRect` to avoid causing an extra reflow.",
+			});
 		},
 	}),
 };
-
-export = rule;

--- a/src/prefer-use-layout-effect.ts
+++ b/src/prefer-use-layout-effect.ts
@@ -1,0 +1,35 @@
+import { Rule } from "eslint";
+import { TSESTree } from "@typescript-eslint/experimental-utils";
+
+const rule: Rule.RuleModule = {
+	meta: {
+		type: "suggestion",
+		docs: {
+			description: "`getBoundinggClientRect` is expensive, so it should be used in `useLayoutEffect`.",
+			category: "Best Practices",
+			recommended: true,
+		},
+	},
+	create: (context) => ({
+		CallExpression(node: TSESTree.CallExpression) {
+			const { callee } = node;
+			if (
+				callee.type === "MemberExpression" &&
+				callee.object.type === "CallExpression" &&
+				callee.object.callee.property &&
+				callee.object.callee.property.name === "getBoundingClientRect" &&
+				callee.object.callee.object &&
+				callee.object.callee.object.type === "ThisExpression" &&
+				callee.object.callee.object.type === "Identifier" &&
+				callee.object.callee.object.name === "useEffect"
+			) {
+				context.report({
+					node,
+					message: "Prefer using useLayoutEffect with getBoundingClientRect.",
+				});
+			}
+		},
+	}),
+};
+
+export = rule;


### PR DESCRIPTION
Hey!

I added 3 new rules that might also be in scope of "performance". If they don't fit this plugin, let me know.

Source for the `useLayoutEffect` one: https://webperf.tips/tip/layout-thrashing/#react-development. It could probably be extended to other JS fns like `getClientRects()`, `getcomputedstyle()`, `offsetHeight` etc.